### PR TITLE
Make gel-typography available as a npm dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We recommend that you use a package manager ([Bower](http://bower.io/) or [NPM](
 ### Install using Bower
 
 ```Shell
-$ bower install --save https://github.com/bbc-gel/gel-typography.git
+$ bower install --save https://github.com/bbc/gel-typography.git
 ```
 
 Once installed, use a Sass `@import` to bring the component into your project:
@@ -24,7 +24,9 @@ Once installed, use a Sass `@import` to bring the component into your project:
 
 ### Install using NPM
 
-[Coming Soon]
+```Shell
+$ npm install --save node_modules/bbc/gel-typography
+```
 
 ### Install manually
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "gel-typography",
+  "version": "0.6.0-beta",
+  "description": "A flexible code implementation of the GEL responsive typography guidelines.",
+  "main": "_settings.scss",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bbc/gel-typography.git"
+  },
+  "keywords": [
+    "bbc",
+    "gel",
+    "typography"
+  ],
+  "author": "BBC",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/bbc/gel-typography/issues"
+  },
+  "homepage": "https://github.com/bbc/gel-typography",
+  "dependencies": {
+    "gel-settings": "git+ssh://github.com/bbc/gel-settings.git#0.3.0",
+    "gel-tools": "git+ssh://github.com/bbc/gel-tools.git#0.3.0"
+  }
+}


### PR DESCRIPTION
Although gel-settings and gel-tools have to be npm-ified as well.

Is there any blocker to publish that on npm? And do you have plans to make the gel-fonticon available as well? Would be amazing :-)

Sass importer could be levered to lookup within npm dependencies more efficiently.
A short take on it lies here: http://stackoverflow.com/questions/28283652/importing-sass-through-npm/29567078#29567078

closes #9 
