### PR TITLE
fix npm dependency issues preventing npm module support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Bower
 bower_components/*
 
+# NPM
+node_modules/*
+
 # Misc
 .DS_Store
 .DS_Store?

--- a/README.md
+++ b/README.md
@@ -24,7 +24,16 @@ Once installed, use a Sass `@import` to bring the component into your project:
 
 ### Install using NPM
 
-[Coming Soon]
+
+```Shell
+$ npm install --save git+ssh://git@github.com/bbc/gel-typography.git
+```
+
+As above, use a Sass `@import` to bring in the component:
+
+```Sass
+@import 'node_modules/gel-typography/typography';
+```
 
 ### Install manually
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/bbc/gel-typography",
   "dependencies": {
-    "gel-settings": "git+ssh://github.com/bbc/gel-settings.git#0.4.0",
-    "gel-tools": "git+ssh://github.com/bbc/gel-tools.git#0.4.0"
+    "gel-settings": "git+ssh://git@github.com/bbc/gel-settings.git#0.4.0",
+    "gel-tools": "git+ssh://git@github.com/bbc/gel-tools.git#0.4.0"
   }
 }


### PR DESCRIPTION
There are some small problems with npm dependency support which I think can be easily fixed.

Specifically, the urls in the package.json are in the wrong format, as a result that a fresh 'npm install' inside the project will fail (and any project that includes this via npm will also fail when it tries to pull the downstream dependencies). The fix is tiny and makes the module completely npm compatible for both of the above.

Updated the README.md with the changes.

Finally, added node_modules to the .gitignore for those who want to develop this repo via npm.
