### PR TITLE
Simplify Dependency Graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ You can install this component manually by downloading the content of this Git r
 
 In order to use the component you will need the following components available:
 
-- [GEL Sass Tools](https://github.com/bbc/gel-sass-tools)
 - [Sass MQ](https://github.com/sass-mq/sass-mq)
 
 ## Usage
@@ -148,7 +147,7 @@ $gel-type-settings: (
 
 We operate a [touch-first](http://www.bbc.co.uk/gel/guidelines/how-to-design-for-touch) approach to our Typography. Group C (touch) sizes are used from 600px by default and then detection should be used to get the Group D (non-touch) sizes.
 
-We also understand that touch detection is not an absolute measure and does not guarantee a 'true or false' outcome - this is okay.  
+We also understand that touch detection is not an absolute measure and does not guarantee a 'true or false' outcome - this is okay.
 
 ### Why not just have Group C and remove Group D?
 

--- a/_typography.scss
+++ b/_typography.scss
@@ -2,13 +2,6 @@
 //    # GEL TYPOGRAPHY
 //\*------------------------------------*/
 
-// We need to check that the GEL settings are available globally
-$gel-settings-available: false !default;
-@if ($gel-settings-available == false) {
-    @warn "Missing Dependency: Have you included the GEL settings?";
-}
-
-
 // import the local dependancies
 @import 'lib/settings';
 @import 'lib/tools';

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
     "dist"
   ],
   "dependencies": {
-    "gel-sass-tools": "git@github.com:bbc/gel-sass-tools.git#^1.0.0"
+    "sass-mq": "^3.2.3"
   },
   "version": "1.0.0"
 }

--- a/lib/_settings.scss
+++ b/lib/_settings.scss
@@ -16,7 +16,7 @@
 //
 // @type String
 //
-$gel-type-namespace: $gel-namespace !default;
+$gel-type-namespace: 'gel-' !default;
 
 // The classname used to signify if the device needs to display the no-touch group. This
 // class needs to be applied to high level elemet such as `body` or `html`
@@ -36,6 +36,11 @@ $gel-type-base-group: 'group-a';
 // @type String
 //
 $gel-type-no-touch-group: 'group-d';
+
+// The base font-size to be used for convertiing px to rem values
+//
+// @type Length
+$gel-type-html-font-size: 16px !default;
 
 
 /// Output configuration
@@ -60,6 +65,16 @@ $gel-type-enable--font-family: false !default;
 // @type String
 //
 $gel-type-enable--base-elements: false !default;
+
+// Should we output REM values (if true)
+//
+// @type Boolean
+$gel-type-enable--rem-output: true !default;
+
+// Should we output PX values as a fallback (if true)
+//
+// @type Boolean
+$gel-type-enable--rem-fallback: true !default;
 
 
 // The GEL typography specification for each type class at each type group.

--- a/lib/_tools.scss
+++ b/lib/_tools.scss
@@ -119,9 +119,45 @@
 @mixin _gel-output-type-values($type-values) {
     @each $property, $value in $type-values {
         @if (type-of($value) == number and unit($value) == 'px') {
-            @include rem($property, $value);
+            @include gel-type-rem($property, $value);
         } @else {
             #{$property}: $value;
         }
+    }
+}
+
+
+@mixin gel-type-rem($property, $value) {
+    // Return the pixel value first
+    @if ($gel-type-enable--rem-fallback == true) {
+        #{$property}: $value;
+    }
+
+    // Pass the px value into the rem function
+    @if ($gel-type-enable--rem-output == true) {
+        #{$property}: gel-type-rem($value);
+    }
+}
+
+
+// 'gel-type-rem' is a Sass function that converts pixel values to rem values
+// for whatever property is passed to it.
+//
+// Source: https://github.com/guardian/guss-rem
+@function gel-type-rem($value, $baseline: $gel-type-html-font-size) {
+    @if $value == 0 {
+        @return 0; // 0rem -> 0
+    }
+
+    @if type-of($value) == list {
+        $result: ();
+
+        @each $e in $value {
+            $result: append($result, gel-type-rem($e, $baseline));
+        }
+
+        @return $result;
+    } @else {
+        @return if(type-of($value) == number and unit($value) == px, $value / $baseline * 1rem, $value);
     }
 }

--- a/package.json
+++ b/package.json
@@ -32,9 +32,8 @@
   "homepage": "https://github.com/bbc/gel-typography",
   "devDependencies": {
     "node-sass": "^3.2.0",
-    "sass-mq": "^3.2.2"
   },
   "dependencies": {
-    "gel-sass-tools": "git+ssh://git@github.com:bbc/gel-sass-tools.git#1.1.0"
+    "sass-mq": "^3.2.3"
   }
 }

--- a/test/test.scss
+++ b/test/test.scss
@@ -2,8 +2,6 @@
 //    # GEL TYPOGRAPHY - TEST
 //\*------------------------------------*/
 
-// Include general GEL dependancies
-@import '../node_modules/gel-sass-tools/sass-tools';
 @import '../node_modules/sass-mq/mq';
 
 


### PR DESCRIPTION
This PR removes the dependency on gel-settings and gel-tools, meaning that the gel-typography now only depends upon sass-mq. Simplifying the dependency graph and making it easier for people to get started with the project.
- Adds a little test-harness that compares node-sass output with an expected output fixture that can be ran using `npm install && npm test`.
- Moves rem functions from gel-tools into _tools, and rename them so they are prefixed with `gel-type-`.
