### PR TITLE
Fix package json

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ $ npm install --save gel-typography
 @import 'node_modules/gel-typography/typography';
 ```
 
+**Note**: The above assumes usage of npm 3 and a flat directory structure. Use
+the below paths if using npm 2
+
+```sass
+// your-app/main.scss
+@import 'node_modules/gel-typography/node_modules/gel-sass-tools/sass-tools';
+@import 'node_modules/gel-typography/node_modules/sass-mq/mq';
+@import 'node_modules/gel-typography/typography';
+```
+
 ### Install manually
 
 You can install this component manually by downloading the content of this Git repo into your project and use a Sass @import to include it in your project.

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
   },
   "homepage": "https://github.com/bbc/gel-typography",
   "devDependencies": {
-    "node-sass": "^3.2.0",
-    "sass-mq": "^3.2.2"
+    "node-sass": "^3.2.0"
   },
   "dependencies": {
-    "gel-sass-tools": "^1.1.0"
+    "gel-sass-tools": "^1.1.0",
+    "sass-mq": "^3.2.2"
   }
 }


### PR DESCRIPTION
`sass-mq` should be installed as a normal dependency so that it gets installed when running `npm install`  in production. Also added a note on using imports in npm 2