### PR TITLE
feat: Remove $core, $enhanced and $fixed variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ v6.0.0 of GEL Typography implements the [@use](https://sass-lang.com/documentati
 
 This has a number of consequences; how modules are loaded, and how to access variables. Namespaces now come into play, so please read the sass documentation links above to learn more.
 
+Previously, the properties output from this module could be controlled via three variables: $core, $enhanced and $fixed. These three variables allowed for control of the output, where core functionality could be separated out from enhanced functionality (for more advanced browsers) and for Internet Explorer (fixed).
+
+As browsers have moved on significantly since this approach was adopted it is considered a good time to remove this functionality.
+
 For usage of GEL Typography prior to v6.0.0 please reference the [v5.2.0 readme](https://github.com/bbc/gel-typography/tree/5.2.0).
 
 

--- a/lib/_tools.scss
+++ b/lib/_tools.scss
@@ -11,7 +11,6 @@
 //\*------------------------------------*/
 
 // define some output control variables
-$core: true !default;
 $enhanced: true !default;
 
 // If larger font sizes enable, merge them with gel-type-settings
@@ -110,11 +109,9 @@ $enhanced: true !default;
 // @author Adam Bulmer
 //
 @mixin gel-typography($type-class) {
-  @if $core {
-    $groupA: gel-typography($type-class, 'group-a');
-    @include _gel-output-type-values($groupA);
-    @include reith-letter-spacing($groupA);
-  }
+  $groupA: gel-typography($type-class, 'group-a');
+  @include _gel-output-type-values($groupA);
+  @include reith-letter-spacing($groupA);
 
   @if $enhanced {
     @include mq.mq($from: gel-bp-type-b) {

--- a/lib/_tools.scss
+++ b/lib/_tools.scss
@@ -13,7 +13,6 @@
 // define some output control variables
 $core: true !default;
 $enhanced: true !default;
-$fixed: false !default;
 
 // If larger font sizes enable, merge them with gel-type-settings
 @if settings.$gel-type-enable--larger-type-sizes {

--- a/lib/_tools.scss
+++ b/lib/_tools.scss
@@ -10,9 +10,6 @@
 //    # GEL TYPOGRAPHY - TOOL
 //\*------------------------------------*/
 
-// define some output control variables
-$enhanced: true !default;
-
 // If larger font sizes enable, merge them with gel-type-settings
 @if settings.$gel-type-enable--larger-type-sizes {
   settings.$gel-type-settings: map.merge(settings.$gel-type-settings, settings.$gel-larger-font-sizes);
@@ -113,23 +110,21 @@ $enhanced: true !default;
   @include _gel-output-type-values($groupA);
   @include reith-letter-spacing($groupA);
 
-  @if $enhanced {
-    @include mq.mq($from: gel-bp-type-b) {
-      $groupB: gel-typography($type-class, 'group-b');
-      @include _gel-output-type-values($groupB);
-      @include reith-letter-spacing($groupB);
-    }
+  @include mq.mq($from: gel-bp-type-b) {
+    $groupB: gel-typography($type-class, 'group-b');
+    @include _gel-output-type-values($groupB);
+    @include reith-letter-spacing($groupB);
+  }
 
-    @include mq.mq($from: gel-bp-type-c) {
-      $groupC: gel-typography($type-class, 'group-c');
-      @include _gel-output-type-values($groupC);
-      @include reith-letter-spacing($groupC);
+  @include mq.mq($from: gel-bp-type-c) {
+    $groupC: gel-typography($type-class, 'group-c');
+    @include _gel-output-type-values($groupC);
+    @include reith-letter-spacing($groupC);
 
-      .#{settings.$gel-type-touch-class} & {
-        $groupNoTouch: gel-typography($type-class, settings.$gel-type-no-touch-group);
-        @include _gel-output-type-values($groupNoTouch);
-        @include reith-letter-spacing($groupNoTouch);
-      }
+    .#{settings.$gel-type-touch-class} & {
+      $groupNoTouch: gel-typography($type-class, settings.$gel-type-no-touch-group);
+      @include _gel-output-type-values($groupNoTouch);
+      @include reith-letter-spacing($groupNoTouch);
     }
   }
 }


### PR DESCRIPTION
## Description
These three variables allowed for control of the output, where `core` functionality could be separated out from `enhanced` functionality (for more advanced browsers) and for Internet Explorer (`fixed`).

As browsers have moved on significantly since this approach was adopted it is considered a good time to remove this functionality.