### PR TITLE
chore: Avoid pre and post scripts

### DIFF
--- a/codebuild/releasespec.yml
+++ b/codebuild/releasespec.yml
@@ -17,7 +17,7 @@ phases:
     on-failure: ABORT
     commands:
       - npm run build
- 
+
   post_build:
     on-failure: ABORT
     commands:

--- a/lib/_settings.scss
+++ b/lib/_settings.scss
@@ -1,7 +1,6 @@
 @use 'sass-mq/mq';
 @use 'gel-sass-tools/sass-tools';
 
-
 ///*------------------------------------*\
 //    # GEL TYPOGRAPHY - SETTINGS
 //\*------------------------------------*/

--- a/lib/_tools.scss
+++ b/lib/_tools.scss
@@ -1,5 +1,5 @@
 @use 'sass-mq/mq';
-@use 'gel-sass-tools/sass-tools' ;
+@use 'gel-sass-tools/sass-tools';
 @use 'settings';
 @use 'sass:map';
 @use 'sass:math';
@@ -12,7 +12,10 @@
 
 // If larger font sizes enable, merge them with gel-type-settings
 @if settings.$gel-type-enable--larger-type-sizes {
-  settings.$gel-type-settings: map.merge(settings.$gel-type-settings, settings.$gel-larger-font-sizes);
+  settings.$gel-type-settings: map.merge(
+    settings.$gel-type-settings,
+    settings.$gel-larger-font-sizes
+  );
 }
 
 // Replace `$search` with `$replace` in `$string`

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "A flexible code implementation of the GEL Typography",
   "main": "_typography.scss",
   "scripts": {
-    "build": "npm run build:compressed && npm run build:expanded",
-    "build:compressed": "sass --load-path=node_modules/ --style=compressed --no-source-map src/gel-typography.scss dist/gel-typography.min.css",
-    "build:expanded": "sass --load-path=node_modules/ --style=expanded --no-source-map src/gel-typography.scss dist/gel-typography.css",
-    "prettier": "prettier --write '{src/**/*,test/**/*,*}.{js,mjs,json,scss}'",
-    "pretest": "npm run prettier",
-    "test": "jest"
+    "build": "npm run sass:compressed && npm run sass:expanded",
+    "jest": "jest",
+    "sass:compressed": "sass --load-path=node_modules/ --style=compressed --no-source-map src/gel-typography.scss dist/gel-typography.min.css",
+    "sass:expanded": "sass --load-path=node_modules/ --style=expanded --no-source-map src/gel-typography.scss dist/gel-typography.css",
+    "prettier": "prettier . '!**/*.md' '!dist/**/*' --write",
+    "test": "npm run prettier && npm run jest"
   },
   "repository": {
     "type": "git",

--- a/test/__snapshots__/typography.test.js.snap
+++ b/test/__snapshots__/typography.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`GEL Typography larger type sizes Atlas 1`] = `
 ".atlas {


### PR DESCRIPTION
## Description
Using `npm config set ignore-scripts true` means that any scripts with `pre...` and `post...` will no longer run. Whilst this may improve the security around npm scripts it does mean that the workflows need to be adjusted - which is what this PR does.

At the same time the package.json prettier command has been updated to ensure more files are formatted consistently.